### PR TITLE
Issue #18: Add supports for stamps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+lerna.json
+tsconfig.json

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -85,19 +85,18 @@ The property level portions of a [Struct](#struct)
 | [linkedStruct](#field-linked-struct) | Indicates a relationship to another struct        |
 | [list](#field-list)                  | A preset list of possible values                  |
 | [derived](#field-derived)            | A value derived from the values of other fields   |
-| stamp                                |                                                   |
 
 ### <a name="block"></a> Block
 
 A grouping of fields displayed in the UI
 
-| Field     | Type                                                                                 | Required | Notes                                                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| name      | keyword                                                                              | true     | The common name used to identify the block                                                                                            |
-| label     | string or [Label](#label)                                                            | false    | Describes the block in the UI                                                                                                         |
-| condition | [condition](#condition)                                                              | false    | [condition](#condition) evaluated to determine if the block should be displayed                                                       |
-| fields    | Array of Strings and/or [Conditional Field Reference](#conditional_field_reference)s | true     | Array of [Field](#field) names or [Conditional Field Reference](#conditional_field_reference)s included in the block in display order |
-| hints     | [hint](#hint)                                                                        | false    | Display recomendation to the UI                                                                                                       |
+| Field     | Type                                                                             | Required | Notes                                                                           |
+| --------- | -------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------- |
+| name      | keyword                                                                          | true     | The common name used to identify the block                                      |
+| label     | string or [Label](#label)                                                        | false    | Describes the block in the UI                                                   |
+| condition | [condition](#condition)                                                          | false    | The [Condition](#condition) evaluated to determine if the block should be displayed |
+| fields    | (string or [Field Reference](#conditional_field_reference) or [Stamp](#stamp))[] | true     |                                                                                 |
+| hints     | [hint](#hint)                                                                    | false    | Display recomendation to the UI                                                 |
 
 ### <a name="label"></a> Label
 
@@ -114,23 +113,14 @@ one of the following.
 
 Describes a relationship to another struct
 
-| Field      | Type    | Required | Missing Val | Notes                                                                                          |
-| ---------- | ------- | -------- | ----------- | ---------------------------------------------------------------------------------------------- |
-| struct     | keyword | true     |             | The name of the other [struct](#struct)                                                        |
-| block      | string  | false    | default     | The name of the [block](#block) to display in the UI                                           |
+| Field  | Type    | Required | Missing Val | Notes                                                |
+| ------ | ------- | -------- | ----------- | ---------------------------------------------------- |
+| struct | keyword | true     |             | The name of the other [struct](#struct)              |
+| block  | string  | false    | default     | The name of the [block](#block) to display in the UI |
 
 ### <a name="hint"></a> Hint
 
 Recommendations given to the UI about how to display the form element. Applies to [structs](#struct), [fields](#field), and [blocks](#block).
-
-#### [Field](#field) Hints
-
-##### <a name="field-stamp"></a> Additional properties for hints of [type](#type) stamp
-
-| Field             | Type     | Required | Missing Val | Notes                                                        |
-| ----------------- | -------- | -------- | ----------- | ------------------------------------------------------------ |
-| headerSize        | integer  | false    |             | The size of the stamp element when display using the `h` tag |
-| displayClassNames | string[] | false    |             | The CSS class name to append to the stamp element            |
 
 #### [Block](#block) Hints
 
@@ -150,19 +140,27 @@ Recommendations given to the UI about how to display the form element. Applies t
 
 ### <a name="option"></a> Option
 
-| Field | Type                                         | Required | Notes                                      |
-| ----- | -------------------------------------------- | -------- | ------------------------------------------ |
-| label | string or [Label](#label)                    | true     | The display value for the option in the UI |
-| value | value cosistent with the field [type](#type) | true     | The value associated with the option       |
+| Field | Type                                          | Required | Notes                                      |
+| ----- | --------------------------------------------- | -------- | ------------------------------------------ |
+| label | string or [Label](#label)                     | true     | The display value for the option in the UI |
+| value | value consistent with the field [type](#type) | true     | The value associated with the option       |
 
-### <a name="conditional_field_reference"></a> Conditional Field Reference
+### <a name="field_reference"></a> Field Reference
 
-References a Field and defines a condition to be evaluated to determine if the field should be displayed.
+References a [Field](#field) and defines a condition to be evaluated to determine if the field should be displayed.
 
-| Field     | Type                    | Required | Notes                                                                |
-| --------- | ----------------------- | -------- | -------------------------------------------------------------------- |
-| field     | string                  | true     | The name of the field to display                                     |
-| condition | [condition](#condition) | true     | expression to be evaluated to determine if field should be displayed |
+| Field     | Type                    | Required | Notes                                                                    |
+| --------- | ----------------------- | -------- | ------------------------------------------------------------------------ |
+| field     | string                  | true     | The name of the field to display                                         |
+| condition | [condition](#condition) | false    | Expression to be evaluated to determine if the field should be displayed |
+
+### <a name="stamp"></a> Stamp
+
+| Field     | Type                    | Required | Missing Val | Notes                                                                    |
+| --------- | ----------------------- | -------- | ----------- | ------------------------------------------------------------------------ |
+| stamp     | string                  | true     |             |                                                                          |
+| size      | integer                 | false    | 3           | The size of the stamp element when display using the `h` tag             |
+| condition | [condition](#condition) | false    |             | Expression to be evaluated to determine if the stamp should be displayed |
 
 ### <a name="conditional"></a> Condition
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "serve": "preact build && preact serve",
     "dev": "preact watch",
     "lint": "tslint packages",
-    "test": "jest"
+    "test": "jest",
+    "format": "prettier \"**/*.{ts,tsx,js,json}\""
   },
   "devDependencies": {
     "@types/jest": "^23.1.4",
@@ -20,6 +21,7 @@
     "lerna": "^2.11.0",
     "preact-cli": "^2.0.0",
     "preact-cli-plugin-typescript": "^0.2.2",
+    "prettier": "^1.14.0",
     "ts-jest": "^23.0.0",
     "tslint": "^5.10.0",
     "typescript": "^2.9.2"

--- a/packages/forms-renderer-bootstrap3/options.ts
+++ b/packages/forms-renderer-bootstrap3/options.ts
@@ -1,4 +1,5 @@
 import { RendererOptions } from '@de-re-crud/forms/models/renderer-options';
+import Bootstrap3StampRenderer from './renderers/stamp-renderer';
 import Bootstrap3ButtonRenderer from './renderers/button-renderer';
 import Bootstrap3FieldContainerRenderer from './renderers/field-container-renderer';
 import Bootstrap3InputFieldRenderer from './renderers/input-field-renderer';
@@ -6,12 +7,12 @@ import Bootstrap3BooleanFieldRenderer from './renderers/boolean-field-renderer';
 import Bootstrap3ListFieldRenderer from './renderers/list-field-renderer';
 import Bootstrap3TableLinkedStructFieldRenderer from './renderers/table-linked-struct-field-renderer';
 import Bootstrap3InlineLinkedStructFieldRenderer from './renderers/inline-linked-struct-field-renderer';
-
 import 'bootstrap/dist/css/bootstrap.css';
 
 const Bootstrap3RendererOptions: RendererOptions = {
   formClassName: 'de-re-crud-form-bootstrap3',
   components: {
+    stamp: Bootstrap3StampRenderer,
     button: Bootstrap3ButtonRenderer,
     fieldContainer: Bootstrap3FieldContainerRenderer,
     textField: Bootstrap3InputFieldRenderer,
@@ -26,8 +27,7 @@ const Bootstrap3RendererOptions: RendererOptions = {
     tableLinkedStructField: Bootstrap3TableLinkedStructFieldRenderer,
     inlineLinkedStructField: Bootstrap3InlineLinkedStructFieldRenderer,
     listField: Bootstrap3ListFieldRenderer,
-    derivedField: Bootstrap3InputFieldRenderer,
-    stampField: Bootstrap3InputFieldRenderer
+    derivedField: Bootstrap3InputFieldRenderer
   }
 };
 

--- a/packages/forms-renderer-bootstrap3/renderers/stamp-renderer.css
+++ b/packages/forms-renderer-bootstrap3/renderers/stamp-renderer.css
@@ -1,0 +1,3 @@
+h5.bootstrap3-stamp-renderer {
+    font-weight: bold;
+}

--- a/packages/forms-renderer-bootstrap3/renderers/stamp-renderer.tsx
+++ b/packages/forms-renderer-bootstrap3/renderers/stamp-renderer.tsx
@@ -1,0 +1,14 @@
+import { h } from 'preact';
+import { StampRendererProps } from '@de-re-crud/forms/models/renderers';
+import './stamp-renderer.css';
+
+const Bootstrap3StampRenderer = ({
+  text,
+  size
+}: StampRendererProps) => {
+  const HeaderComponent = `h${size}`;
+
+  return (<HeaderComponent className="bootstrap3-stamp-renderer">{text}</HeaderComponent>);
+};
+
+export default Bootstrap3StampRenderer;

--- a/packages/forms/form/form.actions.ts
+++ b/packages/forms/form/form.actions.ts
@@ -2,7 +2,6 @@ import { StoreState, Errors, ChildErrors } from '../store';
 import { validateField } from '../utils/validation-helper';
 import { ILinkedStructField, IBlock } from '../models/schema';
 import generateChildErrors from '@de-re-crud/forms/utils/generate-child-errors';
-import { resolve } from 'url';
 
 type ValidationResult = {
   errors: Errors;

--- a/packages/forms/form/form.component.tsx
+++ b/packages/forms/form/form.component.tsx
@@ -15,14 +15,6 @@ export default class Form extends Component<FormProps, FormState> {
     return shallowCompare(this, nextProps, nextState);
   }
 
-  onSubmit = () => {
-    this.props.submitForm();
-  };
-
-  onBack = () => {
-    this.props.pop();
-  };
-
   render({
     className,
     structs,
@@ -30,7 +22,9 @@ export default class Form extends Component<FormProps, FormState> {
     block,
     rendererOptions,
     navStack,
-    submitting
+    submitting,
+    submitForm,
+    pop
   }: FormProps) {
     let visibleBlock: string;
     let visibleStruct: string;
@@ -84,11 +78,11 @@ export default class Form extends Component<FormProps, FormState> {
         {!navStack.length ? (
           <ButtonRenderer
             text="Submit"
-            onClick={this.onSubmit}
+            onClick={submitForm}
             disabled={submitting}
           />
         ) : (
-          <ButtonRenderer text="Back" onClick={this.onBack} />
+          <ButtonRenderer text="Back" onClick={pop} />
         )}
       </form>
     );

--- a/packages/forms/models/renderer-options.ts
+++ b/packages/forms/models/renderer-options.ts
@@ -6,12 +6,16 @@ import {
   TableLinkedStructRendererProps,
   ListFieldRendererProps,
   ButtonRendererProps,
-  InlinedLinkedStructRendererProps
+  InlinedLinkedStructRendererProps,
+  StampRendererProps
 } from '../models/renderers';
 
 export interface RendererOptions {
   formClassName?: string;
   components: {
+    stamp:
+    | FunctionalComponent<StampRendererProps>
+    | ComponentConstructor<StampRendererProps>;
     button:
       | FunctionalComponent<ButtonRendererProps>
       | ComponentConstructor<ButtonRendererProps>;
@@ -55,9 +59,6 @@ export interface RendererOptions {
       | FunctionalComponent<ListFieldRendererProps>
       | ComponentConstructor<ListFieldRendererProps>;
     derivedField:
-      | FunctionalComponent<FieldRendererProps>
-      | ComponentConstructor<FieldRendererProps>;
-    stampField:
       | FunctionalComponent<FieldRendererProps>
       | ComponentConstructor<FieldRendererProps>;
   };

--- a/packages/forms/models/renderers.ts
+++ b/packages/forms/models/renderers.ts
@@ -1,10 +1,15 @@
-import { FieldType, IOption } from './schema';
+import { FieldType, IOption, StampSize } from './schema';
 
 export interface FieldContainerRendererProps {
   fieldName: string;
   fieldDescription?: string;
   errors: string[];
   children?: JSX.Element[];
+}
+
+export interface StampRendererProps {
+  text: string;
+  size: StampSize;
 }
 
 export type FieldFocusEvent = FocusEvent;

--- a/packages/forms/models/schema.ts
+++ b/packages/forms/models/schema.ts
@@ -1,4 +1,4 @@
-export type HeaderSize = 1 | 2 | 3 | 4 | 5 | 6;
+export type StampSize = 1 | 2 | 3 | 4 | 5 | 6;
 
 export type FieldConditionFunc = (fieldParent: any, form: any) => boolean;
 export type BlockConditionFunc = (form: any) => boolean;
@@ -43,14 +43,6 @@ export interface IField {
   initialValue?: any;
   missingValue?: any;
   placeholder?: string;
-}
-
-export interface IStampField extends IField {
-  type: 'stamp';
-  hints: {
-    headerSize: HeaderSize;
-    displayClassNames: string[];
-  };
 }
 
 export interface ITextField extends IField {
@@ -106,11 +98,19 @@ export interface IBlock {
   name: string;
   label?: ILabel;
   condition: BlockConditionFunc;
+  items: (IFieldReference | ILinkedStructFieldReference | IStamp)[]
   fields: (IFieldReference | ILinkedStructFieldReference)[];
 }
 
 export interface IFieldReference {
   field: IField;
+  condition: FieldConditionFunc;
+}
+
+export interface IStamp {
+  text: string;
+  size: StampSize;
+  blockInstance: number;
   condition: FieldConditionFunc;
 }
 

--- a/packages/forms/renderer-hosts/block-host-renderer/block-host-renderer.component.tsx
+++ b/packages/forms/renderer-hosts/block-host-renderer/block-host-renderer.component.tsx
@@ -1,10 +1,12 @@
 import { h, Component } from 'preact';
-import FieldHostRenderer from '@de-re-crud/forms/renderer-hosts/field-host-renderer';
-import { BlockHostRendererProps } from '@de-re-crud/forms/renderer-hosts/block-host-renderer/block-host-renderer.props';
+import { IFieldReference, IStamp } from '../../models/schema';
+import StampHostRenderer from '../stamp-host-renderer';
+import FieldHostRenderer from '../field-host-renderer';
+import { BlockHostRendererProps } from './block-host-renderer.props';
 
 export default class BlockHostRenderer extends Component<
   BlockHostRendererProps
-> {
+  > {
   render({ struct, block, path, formValue }: BlockHostRendererProps) {
     if (!block.condition(formValue)) {
       return null;
@@ -12,13 +14,33 @@ export default class BlockHostRenderer extends Component<
 
     return (
       <div class="de-re-crud-block-renderer">
-        {block.fields.map(fieldReference => (
-          <FieldHostRenderer
-            key={`${struct}${path && `-${path}`}-${fieldReference.field.name}`}
-            fieldReference={fieldReference}
-            path={path}
-          />
-        ))}
+        {block.items.map(item => {
+          const stamp = item as IStamp;
+          if (stamp.text) {
+            return (
+              <StampHostRenderer
+                key={`${struct}${path && `-${path}`}-stamp-${
+                  stamp.blockInstance
+                  }`}
+                stamp={stamp}
+                parentPath={path}
+              />
+            );
+          }
+
+          const fieldReference = item as IFieldReference;
+          if (fieldReference.field) {
+            return (
+              <FieldHostRenderer
+                key={`${struct}${path && `-${path}`}-${
+                  fieldReference.field.name
+                  }`}
+                fieldReference={fieldReference}
+                parentPath={path}
+              />
+            );
+          }
+        })}
       </div>
     );
   }

--- a/packages/forms/renderer-hosts/block-host-renderer/block-host-renderer.props.ts
+++ b/packages/forms/renderer-hosts/block-host-renderer/block-host-renderer.props.ts
@@ -1,4 +1,5 @@
 import { IBlock } from '../../models/schema';
+import { RendererOptions } from '../../models/renderer-options';
 
 export type BlockHostRendererConnectProps = {
   struct: string;

--- a/packages/forms/renderer-hosts/block-host-renderer/index.tsx
+++ b/packages/forms/renderer-hosts/block-host-renderer/index.tsx
@@ -6,7 +6,7 @@ import BlockHostRenderer from './block-host-renderer.component';
 const mapToProps = ({
   value
 }: StoreState): Partial<BlockHostRendererProps> => ({
-  formValue: value
+  formValue: value,
 });
 
 export default connect(mapToProps)(BlockHostRenderer);

--- a/packages/forms/renderer-hosts/field-host-renderer/field-host-renderer.component.tsx
+++ b/packages/forms/renderer-hosts/field-host-renderer/field-host-renderer.component.tsx
@@ -261,10 +261,6 @@ export default class FieldHostRenderer extends Component<
         const DerivedFieldRenderer = rendererOptions.components.derivedField;
         return <DerivedFieldRenderer {...fieldProps} />;
       }
-      case 'stamp': {
-        const StampFieldRenderer = rendererOptions.components.stampField;
-        return <StampFieldRenderer {...fieldProps} />;
-      }
       default: {
         Logger.error(`Field type ${field.type} is not supported.`);
         return null;

--- a/packages/forms/renderer-hosts/field-host-renderer/field-host-renderer.props.ts
+++ b/packages/forms/renderer-hosts/field-host-renderer/field-host-renderer.props.ts
@@ -5,7 +5,7 @@ import { NavState } from '../../store';
 import { CollectionReferences } from '../../form/form.props';
 
 export type FieldHostRendererConnectProps = {
-  path?: string;
+  parentPath?: string;
   fieldReference: IFieldReference;
 };
 

--- a/packages/forms/renderer-hosts/field-host-renderer/index.tsx
+++ b/packages/forms/renderer-hosts/field-host-renderer/index.tsx
@@ -23,26 +23,18 @@ const mapToProps = (
     fieldReference: {
       field: { name }
     },
-    path
+    parentPath,
   }: FieldHostRendererConnectProps
 ): Partial<FieldHostRendererProps> => {
-  const fieldPath = path
-    ? `${path}.${name}`
+  const fieldPath = parentPath
+    ? `${parentPath}.${name}`
     : name;
-
-  const pathArray = fieldPath.split('.');
-
-  const parentPath =
-    pathArray.length < 2
-      ? null
-      : pathArray.slice(0, pathArray.length - 1).join('.');
 
   return {
     fieldPath,
     touched: touched[fieldPath] || false,
     errors: errors[fieldPath] || [],
     childErrors: childErrors[fieldPath] || {},
-    parentPath,
     formValue: value,
     rendererOptions,
     collectionReferences

--- a/packages/forms/renderer-hosts/stamp-host-renderer/index.tsx
+++ b/packages/forms/renderer-hosts/stamp-host-renderer/index.tsx
@@ -1,0 +1,17 @@
+import { connect } from 'redux-zero/preact';
+import { StoreState } from '../../store';
+import formPathToValue from '../../utils/form-path-to-value';
+import { StampHostRendererProps, StampHostRendererConnectProps } from './stamp-host-renderer.props';
+import StampHostRenderer from './stamp-host-renderer.component';
+
+const mapToProps = ({
+  value, rendererOptions
+}: StoreState, {
+  parentPath
+}: StampHostRendererConnectProps): Partial<StampHostRendererProps> => ({
+  rendererOptions,
+  formValue: value,
+  parentValue: parentPath ? formPathToValue(value, parentPath) : value
+});
+
+export default connect(mapToProps)(StampHostRenderer);

--- a/packages/forms/renderer-hosts/stamp-host-renderer/stamp-host-renderer.component.tsx
+++ b/packages/forms/renderer-hosts/stamp-host-renderer/stamp-host-renderer.component.tsx
@@ -1,0 +1,16 @@
+import { h, Component } from 'preact';
+import { StampHostRendererProps } from './stamp-host-renderer.props';
+
+export default class StampHostRenderer extends Component<StampHostRendererProps> {
+  render({ stamp, formValue, parentValue, rendererOptions }: StampHostRendererProps) {
+    if (!stamp.condition(parentValue, formValue)) {
+      return null;
+    }
+
+    const StampRenderer = rendererOptions.components.stamp;
+
+    return (
+      <StampRenderer text={stamp.text} size={stamp.size} />
+    );
+  }
+}

--- a/packages/forms/renderer-hosts/stamp-host-renderer/stamp-host-renderer.props.ts
+++ b/packages/forms/renderer-hosts/stamp-host-renderer/stamp-host-renderer.props.ts
@@ -1,0 +1,14 @@
+import { IStamp } from "../../models/schema";
+import { RendererOptions } from "../../models/renderer-options";
+
+export type StampHostRendererConnectProps = {
+  stamp: IStamp;
+  parentPath?: string;
+}
+
+export type StampHostRendererProps = {
+  stamp: IStamp;
+  formValue: object;
+  parentValue: object;
+  rendererOptions: RendererOptions 
+}

--- a/packages/schema-builder/schema.json
+++ b/packages/schema-builder/schema.json
@@ -221,6 +221,11 @@
           "unique",
           "keyField",
           "type",
+          { 
+            "stamp": "Additional Type Options",
+            "size": 5,
+            "condition": "fieldParent.type === 'text' || fieldParent.type === 'integer' || fieldParent.type === 'derived' || fieldParent.type === 'linkedStruct' || fieldParent.type === 'list'"
+          },
           {
             "field": "minlength",
             "condition": "fieldParent.type === 'text'"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6679,6 +6679,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
+
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"


### PR DESCRIPTION
Instead of stamps being renderered as fields, they are now special references that can be used directly in blocks.

Fixes #18